### PR TITLE
Add coi info, add metadata fields, additional formatting

### DIFF
--- a/content/10.diagnostics.md
+++ b/content/10.diagnostics.md
@@ -1,2 +1,2 @@
-##Diagnostics  {.page_break_before} 
+## Diagnostics  {.page_break_before} 
 This section will include a review of the available information about diagnostics.

--- a/content/70.coi-contribs.md
+++ b/content/70.coi-contribs.md
@@ -1,0 +1,13 @@
+## Additional Items {.page_break_before} 
+
+### Competing Interests
+
+|Author|Competing Interests|Last Reviewed|
+|---|---|---|{% for author in manubot.authors %}
+|{{author.name}}|{{author.coi.string}}|{{author.coi.lastapproved}}|{% endfor %}
+
+### Author Contributions
+
+|Author|Contributions|
+|---|---|{% for author in manubot.authors %}
+|{{author.name}}|{% for contribution in author.contributions %}{{ contribution }}{% if not loop.last %}, {% endif %}{% endfor %}|{% endfor %}

--- a/content/80.example-formatting.md
+++ b/content/80.example-formatting.md
@@ -1,3 +1,5 @@
+# Formatting Examples   {.page_break_before} 
+
 This manuscript is a template (aka "rootstock") for [Manubot](https://manubot.org/ "Manubot"), a tool for writing scholarly manuscripts.
 Use this template as a starting point for your manuscript.
 

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -19,6 +19,10 @@ authors:
       - Writing - Original Draft
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania, Philadelphia, Pennsylvania, United States of America
+    coi:
+      string: "None"
+      lastapproved: !!str 2020-03-22
+    funders: the Gordon and Betty Moore Foundation (GBMF 4552)
   -
     github: cgreene
     name: Casey S. Greene
@@ -31,3 +35,7 @@ authors:
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania, Philadelphia, Pennsylvania, United States of America
       - Childhood Cancer Data Lab, Alex's Lemonade Stand Foundation, Philadelphia, Pennsylvania, United States of America
+    coi:
+      string: "None"
+      lastapproved: !!str 2020-03-22
+    funders: the Gordon and Betty Moore Foundation (GBMF 4552)

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -17,6 +17,7 @@ authors:
     contributions:
       - Project Administration
       - Writing - Original Draft
+      - Methodology
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania, Philadelphia, Pennsylvania, United States of America
     coi:


### PR DESCRIPTION
In this I've ported methods for including COI info as a table from https://github.com/greenelab/deep-review and extended that to author contributions as well. These tables will now appear at the end of the document.

We should ask new contributors to fully fill out these elements. We should probably use the CRediT taxonomy for these elements. 

I'm not sure if what I've done here is "Software" or "Methodology". I do think that your contribution @rando2 for the issue templates & structure in the readme is "Methodology", so I've added that.