### PR TITLE
Add pointer to CDC

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -23,6 +23,15 @@ from [{{manubot.ci_source.repo_slug}}@{{manubot.ci_source.commit | truncate(leng
 on {{manubot.date}}.
 </em></small>
 
+<!-- include the Font Awesome library, per: https://fontawesome.com/start -->
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.13.0/css/all.css">
+[
+[]{.fas .fa-info-circle .fa-lg} **This in progress manuscript is not intended for the general public.**<br>
+This is a review paper that is authored by scientists for an audience of scientists to discuss research that is in progress.
+If you are interested in guidelines on testing, therapies, or other issues related to your health, you should not use this document.
+Instead, you should collect information from your local government or health department, the [CDC's guidance](https://www.cdc.gov/coronavirus/2019-ncov/index.html), or that supplied by your own government.
+]{.banner .lightred}
+
 ## Authors
 
 {## Template for listing authors ##}

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -29,7 +29,7 @@ on {{manubot.date}}.
 []{.fas .fa-info-circle .fa-lg} **This in progress manuscript is not intended for the general public.**<br>
 This is a review paper that is authored by scientists for an audience of scientists to discuss research that is in progress.
 If you are interested in guidelines on testing, therapies, or other issues related to your health, you should not use this document.
-Instead, you should collect information from your local government or health department, the [CDC's guidance](https://www.cdc.gov/coronavirus/2019-ncov/index.html), or that supplied by your own government.
+Instead, you should collect information from your local health department, the [CDC's guidance](https://www.cdc.gov/coronavirus/2019-ncov/index.html), or your own government.
 ]{.banner .lightred}
 
 ## Authors


### PR DESCRIPTION
This sort of closes #53. It adds a note, outlined in red, that this document is not intended for the general public. I pointed folks towards the CDC and mentioned others who may have useful information. What do folks think of this? Especially people who weighed in on #53.