### PR TITLE
Add artifacts instructions, close #31

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -63,15 +63,21 @@ It's possible to see what the document will look like with your changes incorpor
 The first thing that Manubot does is rebuild the document with your changes included.
 You'll know this is completed when you can scroll down to the bottom of your pull request and see "All checks have passed."
 At this point, you can click "Show all checks".
+
 ![show all checks](https://user-images.githubusercontent.com/542643/77359590-2ed13680-6d22-11ea-9cd5-26df2549e546.png "Show all checks link.")
+
 Next, you'll see the various checks that have completed.
 There might be a few of these, and the one you want will be the one from Manubot.
 Click the details link to the right of Manubot.
+
 ![Manubot Details](https://user-images.githubusercontent.com/542643/77359602-35f84480-6d22-11ea-84b3-2b3cf869d43c.png "Manubot details link.")
+
 This will take you to a screen describing what was run.
 You should see a dropdown titled "Artifacts."
 Clicking on that dropdown should reveal something that says "manuscript-..."
+
 ![Artifacts Dropdown](https://user-images.githubusercontent.com/542643/77359613-3abcf880-6d22-11ea-96c2-3ccdbd9b0836.png "Artifacts Dropdown.")
+
 Clicking on the manuscript link will download a zip file to your computer containing the manuscript.
 You should be able to open the PDF in your favorite PDF reader.
 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -64,19 +64,25 @@ The first thing that Manubot does is rebuild the document with your changes incl
 You'll know this is completed when you can scroll down to the bottom of your pull request and see "All checks have passed."
 At this point, you can click "Show all checks".
 
+
 ![show all checks](https://user-images.githubusercontent.com/542643/77359590-2ed13680-6d22-11ea-9cd5-26df2549e546.png "Show all checks link.")
+
 
 Next, you'll see the various checks that have completed.
 There might be a few of these, and the one you want will be the one from Manubot.
 Click the details link to the right of Manubot.
 
+
 ![Manubot Details](https://user-images.githubusercontent.com/542643/77359602-35f84480-6d22-11ea-84b3-2b3cf869d43c.png "Manubot details link.")
+
 
 This will take you to a screen describing what was run.
 You should see a dropdown titled "Artifacts."
 Clicking on that dropdown should reveal something that says "manuscript-..."
 
+
 ![Artifacts Dropdown](https://user-images.githubusercontent.com/542643/77359613-3abcf880-6d22-11ea-96c2-3ccdbd9b0836.png "Artifacts Dropdown.")
+
 
 Clicking on the manuscript link will download a zip file to your computer containing the manuscript.
 You should be able to open the PDF in your favorite PDF reader.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -12,7 +12,7 @@ Have you ever been writing something as a team and found that someone was editin
 Git tracks different people's contributions and manages how they get merged together to avoid the headache of figuring out what changed when.
 
 We are managing this project through GitHub with the goal of a) allowing for the manuscript to evolve rapidly as new information comes out, and b) give everyone credit for their contributions.
-While we believe this is a great tool, we know it can sometimes be intimidating to get started. 
+While we believe this is a great tool, we know it can sometimes be intimidating to get started.
 We don't want the medium to turn anyone away from contributing, so please let us know if you're having problems.
 
 ### Most Important: Make a GitHub account
@@ -23,37 +23,58 @@ As long as you do this first step of making a GitHub account, you will always be
 
 ### GitHub Vocabulary
 
-- [Repository](http://github.com/greenelab/covid19-review): 
-The set of files, issue tracker issues, etc. related to this manuscript 
-- [Issue](https://github.com/greenelab/covid19-review/issues): 
-The ticketing system for GitHub. 
+- [Repository](http://github.com/greenelab/covid19-review):
+The set of files, issue tracker issues, etc. related to this manuscript
+- [Issue](https://github.com/greenelab/covid19-review/issues):
+The ticketing system for GitHub.
 A ticket can be a question, concern, problem, bug, or anything else you want to bring to the attention of the people working on a repository.
 Here, we will use tickets not only for problems or questions, but also to gather papers and preprints that come out about diagnostics and therapeutics related to COVID-19
-- Issue Template: 
-A way of pre-specifying what an "issue" should look like to be useful. 
+- Issue Template:
+A way of pre-specifying what an "issue" should look like to be useful.
 There might be a template that fits your needs (e.g., New Paper, or asking for help with GitHub).
-If not, just try to explain why you're opening the issue (e.g., "I was doing X and ran into problem Y", or "I saw the paper linked here and thought it might be interesting for X reason") 
-- [Manuscript Source](content): 
-The files that comprise the manuscript. 
-These are located in the "content" folder that you see. 
-These are written in a language called ["markdown"](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#lists) which is essentially plain text (thankfully!) 
+If not, just try to explain why you're opening the issue (e.g., "I was doing X and ran into problem Y", or "I saw the paper linked here and thought it might be interesting for X reason")
+- [Manuscript Source](content):
+The files that comprise the manuscript.
+These are located in the "content" folder that you see.
+These are written in a language called ["markdown"](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#lists) which is essentially plain text (thankfully!)
 We have separate a file for each section of the manuscript (Introduction, Pathogenesis, Diagnostics, and Therapeutics right now).
-- [Pull Request](https://github.com/greenelab/covid19-review/pulls) or PR: 
-A request to change the content of the repository in some way. 
+- [Pull Request](https://github.com/greenelab/covid19-review/pulls) or PR:
+A request to change the content of the repository in some way.
 Here, this will usually mean you are adding or editing text.
 
 ### How to Make a Pull Request
 
-1. Look in the [Manuscript Source](content) for the file you want to edit (for example, the [Abstract](content/01.abstract.md)). 
-2. Click the edit button, which looks like a pencil in the upper right corner. 
+1. Look in the [Manuscript Source](content) for the file you want to edit (for example, the [Abstract](content/01.abstract.md)).
+2. Click the edit button, which looks like a pencil in the upper right corner.
 3. Make any desired changes.
-4. Scroll down to the bottom. 
-There you will see a section that says "Commit Changes." 
-Give your submission a title in the top box and briefly summarize your changes in the bottom box. 
-5. Click the box that says "Create a new branch for this commit and start a pull request." 
+4. Scroll down to the bottom.
+There you will see a section that says "Commit Changes."
+Give your submission a title in the top box and briefly summarize your changes in the bottom box.
+5. Click the box that says "Create a new branch for this commit and start a pull request."
 This will submit a request to add your changes to the underlying document and will notify us to integrate your text into the document!
-6. Don't forget to [add your information to the author list](CONTRIBUTING.md). 
+6. Don't forget to [add your information to the author list](CONTRIBUTING.md).
 If you don't have an ORCID, you can make one [here](https://orcid.org/).
+
+### How can I see my change?
+
+If you've made a pull request, congratulations!
+This is a huge step in getting your contributions into the review.
+It's possible to see what the document will look like with your changes incorporated.
+The first thing that Manubot does is rebuild the document with your changes included.
+You'll know this is completed when you can scroll down to the bottom of your pull request and see "All checks have passed."
+At this point, you can click "Show all checks".
+![show all checks](https://user-images.githubusercontent.com/542643/77359590-2ed13680-6d22-11ea-9cd5-26df2549e546.png "Show all checks link.")
+Next, you'll see the various checks that have completed.
+There might be a few of these, and the one you want will be the one from Manubot.
+Click the details link to the right of Manubot.
+![Manubot Details](https://user-images.githubusercontent.com/542643/77359602-35f84480-6d22-11ea-84b3-2b3cf869d43c.png "Manubot details link.")
+This will take you to a screen describing what was run.
+You should see a dropdown titled "Artifacts."
+Clicking on that dropdown should reveal something that says "manuscript-..."
+![Artifacts Dropdown](https://user-images.githubusercontent.com/542643/77359613-3abcf880-6d22-11ea-96c2-3ccdbd9b0836.png "Artifacts Dropdown.")
+Clicking on the manuscript link will download a zip file to your computer containing the manuscript.
+You should be able to open the PDF in your favorite PDF reader.
+
 
 ### Questions
 
@@ -124,4 +145,3 @@ The `gh-pages` branch uses [GitHub Pages](https://pages.github.com/) to host the
 + **PDF manuscript** at https://greenelab.github.io/covid19-review/manuscript.pdf
 
 For continuous integration configuration details, see [`.github/workflows/manubot.yaml`](.github/workflows/manubot.yaml) if using GitHub Actions or [`.travis.yml`](.travis.yml) if using Travis CI.
-


### PR DESCRIPTION
This has come up a couple times. It's not always apparent where the rendered paper is after Manubot finishes building. I understand that there is an effort underway to provide an annotation on the pull request itself. In the interim, I added instructions that we can point people towards to help them find the rendered manuscript.