### PR TITLE
Add Park2020_distancing manual reference

### DIFF
--- a/content/90.back-matter.md
+++ b/content/90.back-matter.md
@@ -1,4 +1,9 @@
+Test new citation [@tag:Park2020_distancing].
+
 ## References {.page_break_before}
 
 <!-- Explicitly insert bibliography here -->
 <div id="refs"></div>
+
+<!-- Define citation tags below -->
+[@tag:Park2020_distancing]: url:https://github.com/parksw3/Korea-analysis/blob/master/v1/korea.pdf

--- a/content/90.back-matter.md
+++ b/content/90.back-matter.md
@@ -1,5 +1,3 @@
-Test new citation [@tag:Park2020_distancing].
-
 ## References {.page_break_before}
 
 <!-- Explicitly insert bibliography here -->

--- a/content/manual-references.bib
+++ b/content/manual-references.bib
@@ -1,0 +1,11 @@
+@article{url:https://github.com/parksw3/Korea-analysis/blob/master/v1/korea.pdf,
+	title = {Potential roles of social distancing in mitigating the spread of coronavirus disease 2019 ({COVID}-19) in {South} {Korea}},
+	url = {https://github.com/parksw3/Korea-analysis/blob/master/v1/korea.pdf},
+	abstract = {On January 20, 2020, the first COVID-19 case was confirmed in South Korea. After a rapid outbreak, the number of incident cases has been consistently decreasing since early March; this decrease has been widely attributed to its intensive testing. We report here on the likely role of social distancing in reducing transmission in South Korea. Our analysis suggests that transmission may still be persisting in some regions.},
+	language = {en},
+	urldate = {2020-03-30},
+	journal = {GitHub},
+	author = {Park, Sang Woo and Sun, Kaiyuan and Viboud, C{\'e}cile and Grenfell, Bryan T and Dushoff, Jonathan},
+	year = {2020},
+	pages = {21}
+}


### PR DESCRIPTION
I'm adding a manual reference for #109.  I need to test whether I set up the `.bib` file correctly before this can be merged.