### PR TITLE
Temporarily don't include all PR data to stay below GH api limit

### DIFF
--- a/build/litsearch/getInternalData.py
+++ b/build/litsearch/getInternalData.py
@@ -210,6 +210,9 @@ def getRelevantPRData():
                 "pull_request_link": PR["html_url"],
                 "diff": diffResponse.text
             })
+            if diffResponse.headers["X-RateLimit-Remaining"] < 2:
+                print('GitHub api rate limit will be exceeded; temporarily not including all PR data while fix is found')
+                break
     return textForReviewPRs
 
 

--- a/build/litsearch/getInternalData.py
+++ b/build/litsearch/getInternalData.py
@@ -210,7 +210,7 @@ def getRelevantPRData():
                 "pull_request_link": PR["html_url"],
                 "diff": diffResponse.text
             })
-            if int(diffResponse.headers["X-RateLimit-Remaining"]) < 2:
+            if int(diffResponse.headers["X-RateLimit-Remaining"]) <= 2:
                 print('GitHub api rate limit will be exceeded; temporarily not including all PR data while fix is found')
                 break
     return textForReviewPRs

--- a/build/litsearch/getInternalData.py
+++ b/build/litsearch/getInternalData.py
@@ -210,7 +210,7 @@ def getRelevantPRData():
                 "pull_request_link": PR["html_url"],
                 "diff": diffResponse.text
             })
-            if diffResponse.headers["X-RateLimit-Remaining"] < 2:
+            if int(diffResponse.headers["X-RateLimit-Remaining"]) < 2:
                 print('GitHub api rate limit will be exceeded; temporarily not including all PR data while fix is found')
                 break
     return textForReviewPRs


### PR DESCRIPTION
<!-- Hi there! Please use the template below as a guide for opening a pull request.
This template is designed to help the pull request process go smoother.
If anything doesn't make sense to you, please open the pull request anyway and leave entries blank as needed.
Thank you for your contribution!! -->

### Description of the proposed additions or changes
<!-- If the additions or changes aren't self explanatory feel free to leave a description or notes here. -->
The getInternalData.py script is currently making more than 60 GitHub API calls (more than the limit) and erroring. We will propose a long term solution soon (maybe caching, maybe using an api key) but don't want the failing build to hold up any other PRs so this lets the build pass by just syncing the PR data up to the point where the limit would be exceeded.

### Suggested reviewers (optional)
<!-- If there are particular people you think should review this pull request, please list their GitHub handle like "@rando2".-->
@agitter 