### PR TITLE
Spellcheck improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,9 @@ test_script:
         SPELLING_ERRORS_FILENAME=spelling-errors-$APPVEYOR_BUILD_VERSION-${TRIGGERING_COMMIT:0:7}.txt
         cp output/spelling-errors.txt $SPELLING_ERRORS_FILENAME
         appveyor PushArtifact $SPELLING_ERRORS_FILENAME
+        SPELLING_ERROR_LOCATIONS_FILENAME=spelling-error-locations-$APPVEYOR_BUILD_VERSION-${TRIGGERING_COMMIT:0:7}.txt
+        cp output/spelling-error-locations.txt $SPELLING_ERROR_LOCATIONS_FILENAME
+        appveyor PushArtifact $SPELLING_ERROR_LOCATIONS_FILENAME
       fi
 
 build: off
@@ -59,8 +62,8 @@ on_success:
   - appveyor AddMessage "$JOB_MESSAGE is now complete."
   - |
       if [ "${SPELLCHECK:-}" = "true" ]; then
-        SPELLING_ERROR_COUNT=($(wc -l $SPELLING_ERRORS_FILENAME))
-        appveyor AddMessage " <details><summary>Found $SPELLING_ERROR_COUNT potential spelling error(s). Preview:</summary>$(head -n 100 $SPELLING_ERRORS_FILENAME)"
+        SPELLING_ERROR_COUNT=($(wc -l $SPELLING_ERROR_LOCATIONS_FILENAME))
+        appveyor AddMessage " <details><summary>Found $SPELLING_ERROR_COUNT potential spelling error(s). Preview:</summary>$(head -n 100 $SPELLING_ERROR_LOCATIONS_FILENAME)"
         appveyor AddMessage "... </details>"
       fi
 

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -651,6 +651,7 @@ nanoparticle
 nanoparticles
 Nanopore
 nasopharyngeal
+naïve
 NCBI
 NCIP
 nCoV

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 1063
+personal_ws-1.1 en 1075 utf-8
 aadattoli
 ABCpred
 ABO

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -66,6 +66,7 @@ BCL
 BCR
 Belhadi
 BepiPred
+Bérengère
 betacoronavirus
 BG
 BH
@@ -122,6 +123,7 @@ cathepsins
 cbrueffer
 CCL
 CCLE
+CDC’s
 cDNA
 CELLECTRA
 Cellex
@@ -175,6 +177,7 @@ coronaviruses
 corticosteroid
 corticosteroids
 CoV
+CoV’s
 COVID
 CoVs
 CoVZC
@@ -214,6 +217,7 @@ Cytometry
 Cytopathic
 cytotoxic
 cytotoxicity
+D'Agostino
 Daegu
 Dalla
 Danoprevir
@@ -346,6 +350,7 @@ ggjvr
 ggkd
 ggnzmc
 GGO
+Ghosh
 github
 Gitter
 glomerular
@@ -360,6 +365,7 @@ glycosylated
 glycosylation
 GOLGA
 GreeneScientist
+greensolid
 GSE
 GTEx
 Guangdong
@@ -585,6 +591,7 @@ maplazumab
 Markus
 Marouen
 marouenbg
+matfax
 Marseille
 Matsuyama
 MAVS
@@ -690,6 +697,7 @@ nucleoprotein
 nucleotides
 nutraceutical
 Nutraceuticals
+O’Meara
 OC
 olfaction
 omics
@@ -882,6 +890,7 @@ s
 SAA
 sACE
 Sadipan
+Salomé
 Samarth
 Sangeun
 SaO
@@ -926,6 +935,8 @@ Skelly
 SL
 SNG
 SNP
+Soumita
+soumitagh
 specialised
 spectrometry
 spergillus

--- a/build/build.sh
+++ b/build/build.sh
@@ -85,12 +85,19 @@ fi
 # Spellcheck
 if [ "${SPELLCHECK:-}" = "true" ]; then
   export ASPELL_CONF="add-extra-dicts $(pwd)/build/assets/custom-dictionary.txt; ignore-case true; ignore 1"
+
+  # Identify and store spelling errors
+  pandoc --lua-filter spellcheck.lua output/manuscript.md | sort -fu > output/spelling-errors.txt
+  echo >&2 "Potential spelling errors:"
+  cat output/spelling-errors.txt
+
+  # Find locations of spelling errors
   # Use "|| true" after grep because otherwise this step of the pipeline will
   # return exit code 1 if any of the markdown files do not contain a
   # misspelled word
-  pandoc --lua-filter spellcheck.lua output/manuscript.md | sort -fu | while read word; do grep -ion "\<$word\>" content/*.md; done | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-errors.txt || true
+  cat output/spelling-errors.txt | while read word; do grep -ion "\<$word\>" content/*.md; done | sort -h -t ":" -k 1b,1 -k2,2 > output/spelling-error-locations.txt || true
   echo >&2 "Filenames and line numbers with potential spelling errors:"
-  cat output/spelling-errors.txt
+  cat output/spelling-error-locations.txt
 fi
 
 # Create sources output if requested via environment variable

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -22,5 +22,5 @@ conda activate manubot
 if [ "${SPELLCHECK:-}" = "true" ]; then
   sudo apt-get update -y
   sudo apt-get install -y aspell aspell-en
-  wget https://raw.githubusercontent.com/agitter/lua-filters/19f6d037f64bf41e28b2891572fb141df24a2b8e/spellcheck/spellcheck.lua
+  wget https://raw.githubusercontent.com/agitter/lua-filters/25066659816b0c05c52da2699bac4ab09b8ca80b/spellcheck/spellcheck.lua
 fi


### PR DESCRIPTION
This update stores two spellcheck outputs as artifacts: the list of unique misspelled words and their locations in the markdown files.  The word list is intended to make it faster to update the custom dictionary.

It also uses my latest version of the lua figure that fixes bugs with accents and Unicode.  That should remove the "re" false positive spelling errors in the appendix here.