### PR TITLE
Typo&RemovedRepetitionClinicalPresentn.Intro.md

### DIFF
--- a/content/02.introduction.md
+++ b/content/02.introduction.md
@@ -157,10 +157,7 @@ Other viral infections have been associated with coagulation defects; notably SA
 A wide range of viral infections can affect the coagulation cascade.
 The mechanism behind these insults has been suggested to be related to inflammation-induced increases in the von Willebrand factor (VWF) clotting protein, leading to a pro-coagulative state [@doi:10.1002/jmv.23354].
 Abnormal clotting (thromboinflammation or coagulopathy) has been increasingly discussed recently as a possible key mechanism in many cases of severe COVID-19, and may be associated with the high d-dimer levels often observed in severe cases [@doi:10/ggvd74; @doi:10.1186/s13054-020-03060-9; @doi:10.1007/s11239-020-02134-3].
-This excessive clotting in lung capillaries has been suggested to related to a dysregulated activation of the complement system, part of the innate immune system [@doi:10.1172/jci.insight.140711;@doi:10.1172/JCI140183].
-
-Individual outcomes have varied significantly, and reported hospitalization rates have been wide-ranging based on age and location, with various underlying health conditions being disproportionately reported [@doi:10.15585/mmwr.mm6915e3].
-Outcomes in patients that are hospitalized have generally been poor, with rates of admission to the intensive care unit (ICU) upwards of 15% in both Wuhan, China and Italy [@doi:10.1056/nejmoa2002032; @doi:10.1001/jama.2020.2648; @doi:10.1001/jama.2020.4031].
+This excessive clotting in lung capillaries has been suggested to be related to a dysregulated activation of the complement system, part of the innate immune system [@doi:10.1172/jci.insight.140711;@doi:10.1172/JCI140183].
 
 #### Subpopulations of Special Concern  
 


### PR DESCRIPTION
Very obvious typo: added "be"
& 2 sentences within Clinical Presentation of COVID-19 subsection are repeated -- they appear both within a central paragraph and at the very end. I removed the repetition at the very end.
(There are other repetitions in the manuscript but I didn't touch those in case there's still reorganization done. These just seemed straightforward leftover repeated sentences to remove)

<!-- Hi there! Please use the template below as a guide for opening a pull request.
This template is designed to help the pull request process go smoother.
If anything doesn't make sense to you, please open the pull request anyway and leave entries blank as needed.
Thank you for your contribution!! -->

### Description of the proposed additions or changes
<!-- If the additions or changes aren't self explanatory feel free to leave a description or notes here. -->


### Related issues
<!-- GitHub will link issues to pull requests if you list the related issue numbers like "#2, #17". -->


### Suggested reviewers (optional)
<!-- If there are particular people you think should review this pull request, please list their GitHub handle like "@rando2".-->


### Checklist
<!-- Please mark the following tasks as complete by putting an "x" in the box like "[x]".
If a particular item is not applicable to your pull request, please delete the item. -->
- [ ] Text is formatted so that each sentence is on its own line.
<!-- see why this is recommended here:https://github.com/greenelab/covid19-review/blob/627a5f45a2d1fcb2150d1466df63bb848f22a3d4/USAGE.md#manubot-markdown -->
- [ ] Pre-prints cited in this pull request have a GitHub issue opened so that they can be reviewed.
