### PR TITLE
Update affiliation guidelines

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -241,7 +241,7 @@ initials: DSH  # optional
 orcid: 0000-0002-3012-7446  # mandatory
 twitter: dhimmel  # optional
 email: daniel.himmelstein@gmail.com  # suggested
-affiliations:  # as a list, strongly suggested
+affiliations:  # as a list, at least one line with institution, city, and country required
   - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
   - Department of Biological & Medical Informatics, University of California, San Francisco
 code of conduct:


### PR DESCRIPTION
Manubot defaults aren't consistent with requirements of _mSystems_, this change requires the info we will need from each author for submission