### PR TITLE
Update EBM script for expanded data frame

### DIFF
--- a/ebmdatalab/generate-ebmdatalab-stats.py
+++ b/ebmdatalab/generate-ebmdatalab-stats.py
@@ -182,7 +182,7 @@ def main(args):
     # https://github.com/ebmdatalab/covid_trials_tracker-covid/blob/6c2b9965b170aa6c53e7f755692a4f221de694bf/notebooks/diffable_python/ictrp_data_handling.py#L544
     header = ['index', 'trial_id', 'registry', 'registration_date', 'start_date', \
               'retrospective_registration', 'sponsor', 'recruitment_status', \
-              'phase', 'study_type', 'countries', 'title', 'study_category', \
+              'phase', 'study_type', 'countries', 'title', 'acronym', 'study_category', \
               'intervention', 'intervention_list', 'enrollment', \
               'primary_completion_date', 'full_completion_date', 'registy_url', \
               'results_type', 'results_published_date', 'results_url', 'last_updated', \


### PR DESCRIPTION
An upstream change to the EBM data https://github.com/ebmdatalab/covid_trials_tracker-covid/pull/27 added a new "acronym" column.  This causes our EMB updates [to fail](https://github.com/greenelab/covid19-review/runs/1034175398?check_suite_focus=true#step:5:9) because there are more data columns than header entries.

Fortunately, the external resources update is robust enough that the latest correct statistics and figure can still be used in manuscript builds.  However, it might be a good idea to add more automated notifications when parts of that scheduled workflow fail.