### PR TITLE
Revert "Update metadata.yaml - Yuchen Sun"

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -613,7 +613,7 @@ authors:
       lastapproved: !!str 2020-11-11
   -
     github: kevinsunofficial
-    name: Yuchen Sun
+    name: YuCheng Sun
     initials: YS
     email: ys4aj@virginia.edu
     contributions:
@@ -624,7 +624,7 @@ authors:
       confirmed: yes
     coi:
       string: "None"
-      lastapproved: !!str 2020-11-11
+      lastapproved: !!str 2020-07-09
   -
     github: qiyanjun
     name: Yanjun Qi


### PR DESCRIPTION
Reverts greenelab/covid19-review#694

Possible trouble-shooting step since we started getting failed builds with this merge. (Nothing to do with authorship!)