### PR TITLE
Make OWID stats available in manuscript

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -27,6 +27,7 @@ if [ "${BUILD_HTML:-}" != "false" ] || [ "${BUILD_PDF:-}" != "false" ] || [ "${B
     --output-directory=output \
     --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/csse/csse-stats.json \
     --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/ebmdatalab/ebmdatalab-stats.json \
+    --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/owiddata/owiddata-stats.json \
     --cache-directory=ci/cache \
     --skip-citations \
     --log-level=INFO
@@ -195,6 +196,7 @@ if [ "${BUILD_INDIVIDUAL:-}" = "true" ]; then
       --output-directory=output/$INDIVIDUAL_KEYWORD \
       --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/csse/csse-stats.json \
       --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/ebmdatalab/ebmdatalab-stats.json \
+      --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/owiddata/owiddata-stats.json \
       --template-variables-path=content/$INDIVIDUAL_KEYWORD/$INDIVIDUAL_KEYWORD.yaml \
       --cache-directory=ci/cache \
       --skip-citations \

--- a/content/manual-references.bib
+++ b/content/manual-references.bib
@@ -56,8 +56,8 @@
 }
 
 @article{owidcoronavirus,
-	author = {Max Roser, Hannah Ritchie, Esteban Ortiz-Ospina and Joe Hasell},
-	title = {Coronavirus Pandemic (COVID-19)},
+	author = {Roser, Max and Ritchie, Hannah and Ortiz-Ospina, Esteban and Hasell, Joe},
+	title = {Coronavirus Pandemic {(COVID-19)}},
 	journal = {Our World in Data},
 	year = {2020},
 	url = {https://ourworldindata.org/coronavirus}


### PR DESCRIPTION
I forgot this was needed in #926 to allow the template variables to be used in the manuscript text.