### PR TITLE
Add CORD-19 resource to workflow and build script

### DIFF
--- a/.github/workflows/update-external-resources.yaml
+++ b/.github/workflows/update-external-resources.yaml
@@ -30,26 +30,29 @@ jobs:
       - name: Update OWID data
         shell: bash --login {0}
         run: bash owiddata/generate-owiddata-stats.sh
-      - name: Commit JHU CSSE and EBM Data Lab figures
+      - name: Update CORD-19 data
+        shell: bash --login {0}
+        run: bash CORD-19/generate-cord19-stats.sh
+      - name: Commit JHU CSSE, EBM Data Lab, and CORD-19 figures
         uses: EndBug/add-and-commit@v4
         with:
           add: '*/*.png */*.svg'
           author_name: GitHub Actions
           author_email: actions@github.com
-          message: 'Update JHU CSSE and EBM Data Lab figures'
+          message: 'Update JHU CSSE, EBM Data Lab, and CORD-19 figures'
           ref: external-resources
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update figure versions
         shell: bash --login {0}
         run: bash version-figures.sh
-      - name: Commit JHU CSSE, EBM Data Lab, and OWID statistics
+      - name: Commit JHU CSSE, EBM Data Lab, OWID, and CORD-19 statistics
         uses: EndBug/add-and-commit@v4
         with:
           add: '*/*.json'
           author_name: GitHub Actions
           author_email: actions@github.com
-          message: 'Update JHU CSSE, EBM Data Lab, and OWID statistics'
+          message: 'Update JHU CSSE, EBM Data Lab, OWID, and CORD-19 statistics'
           ref: external-resources
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/build.sh
+++ b/build/build.sh
@@ -25,6 +25,7 @@ if [ "${BUILD_HTML:-}" != "false" ] || [ "${BUILD_PDF:-}" != "false" ] || [ "${B
   manubot process \
     --content-directory=content \
     --output-directory=output \
+    --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/CORD-19/cord19-stats.json \
     --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/csse/csse-stats.json \
     --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/ebmdatalab/ebmdatalab-stats.json \
     --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/owiddata/owiddata-stats.json \
@@ -194,6 +195,7 @@ if [ "${BUILD_INDIVIDUAL:-}" = "true" ]; then
     manubot process \
       --content-directory=content/$INDIVIDUAL_KEYWORD \
       --output-directory=output/$INDIVIDUAL_KEYWORD \
+      --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/CORD-19/cord19-stats.json \
       --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/csse/csse-stats.json \
       --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/ebmdatalab/ebmdatalab-stats.json \
       --template-variables-path=https://github.com/greenelab/covid19-review/raw/$EXTERNAL_RESOURCES_COMMIT/owiddata/owiddata-stats.json \

--- a/content/60.methods.md
+++ b/content/60.methods.md
@@ -23,6 +23,7 @@ The potential for "excessive publication" has been identified as an issue for ov
 <!--To Do: Flesh out above paragraph--> 
 
 <!--To Do: Insert CORD-19 data viz here, with breakdown by preprint server versus traditional journal? I think this will really help illustrate the various problems outlined in the intro-->
+Test CORD-19 statistics: {{cord19_total_pubs}} total publications.
 <!--To Do: Possible viz of change in clinical trials as well?-->
 
 <!-- To Do: This is just an outline, formalize this paragraph with citations etc-->


### PR DESCRIPTION
This follows up on #941 so that the script to generate CORD-19 statistics and figures is run daily.  It also tests that the statistics are available in the manuscript.