### PR TITLE
Modify CORD-19 script to exit with 0

### DIFF
--- a/CORD-19/generate-cord19-stats.sh
+++ b/CORD-19/generate-cord19-stats.sh
@@ -17,5 +17,5 @@ echo "Generating CORD-19 statistics and figure"
 python CORD-19/generate-cord19-stats.py $CORD19_VERSION $CORD19_STATS_JSON $CORD19_FIG
 
 # Clean up downloaded files
-rm CORD-19/metadata.csv 2> /dev/null
-rm CORD-19/changelog.txt 2> /dev/null
+rm -f CORD-19/metadata.csv
+rm -f CORD-19/changelog.txt


### PR DESCRIPTION
The external resources build [is failing](https://github.com/greenelab/covid19-review/runs/2625662310?check_suite_focus=true) because `CORD-19/generate-cord19-stats.sh` exits with 1.  This should allow it to ignore missing files and still exit with 0.