### PR TITLE
Turn off docx section numbers

### DIFF
--- a/build/pandoc/defaults/docx.yaml
+++ b/build/pandoc/defaults/docx.yaml
@@ -6,3 +6,4 @@ reference-doc: build/themes/default.docx
 resource-path:
  - '.'
  - content
+number-sections: false


### PR DESCRIPTION
The docx section numbering starts with 0.1 for the abstract, and it isn't easy to fix.  This should disable numbered sections only for docx output.

Let's check the artifact before merging.