### PR TITLE
Temporarily disable manuscript stats

### DIFF
--- a/.github/workflows/update-external-resources.yaml
+++ b/.github/workflows/update-external-resources.yaml
@@ -33,9 +33,9 @@ jobs:
       - name: Update CORD-19 data
         shell: bash --login {0}
         run: bash CORD-19/generate-cord19-stats.sh
-      - name: Update manuscript statistics data
-        shell: bash --login {0}
-        run: bash analyze-ms-stats/calc-manuscript-stats.sh
+#      - name: Update manuscript statistics data
+#        shell: bash --login {0}
+#        run: bash analyze-ms-stats/calc-manuscript-stats.sh
       - name: Commit JHU CSSE, EBM Data Lab, OWID, CORD-19, and manuscript growth figures
         uses: EndBug/add-and-commit@v4
         with:


### PR DESCRIPTION
The external resources build failed https://github.com/greenelab/covid19-review/runs/3593275250?check_suite_focus=true

I believe I know how to fix this by using an action to checkout the output branch.  I'll work on it post DISCO-submission.