### PR TITLE
Sync Methods acknowledgements with Overleaf

### DIFF
--- a/content/60.methods.md
+++ b/content/60.methods.md
@@ -325,7 +325,8 @@ The COVID-19 Review Consortium is made of:
 {%- endif %}
 
 ### Acknowledgements {.unnumbered}
-We thank Josh Nicholson and Milo Mordaunt for scite support, David Nicholson for spell-check assistance, Milton Pividori and Consortium members Alex Lee and Christian Brueffer for feedback, and Nick DeVito for assistance with the Evidence-Based Medicine Data Lab COVID-19 TrialsTracker data.
+This work would not be possible without support from the COVID-19 Review Consortium.
+We are also grateful to Nick DeVito for assistance with the Evidence-Based Medicine Data Lab COVID-19 TrialsTracker data, Josh Nicholson and Milo Mordaunt for scite support, David Nicholson for spell-check assistance, and Milton Pividori as well as consortium members Alex Lee and Christian Brueffer for feedback.
 Research was supported by the Gordon and Betty Moore Foundation award GBMF 4552 (HMR, DSH, CSG), the National Institutes of Health award R01HG010067 (HMR, CSG), and the John W. and Jeanne M. Rowe Center for Research in Virology (AG).
 <!--The automatically-updated comment in the TeX output can be used to confirm the above funding statement is still accurate.-->
 {%- endif %}


### PR DESCRIPTION
We were forced by the publisher to remove the consortium author from the DISCO 2021 manuscript.  This acknowledgements update puts more emphasis on the consortium.

The arXiv version still includes the consortium author and will not be modified.