### PR TITLE
Include external figures in subdirectory

### DIFF
--- a/.github/workflows/update-external-resources.yaml
+++ b/.github/workflows/update-external-resources.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     # Run every day at 00:00
     - cron:  '0 0 * * *'
+  # Enable manually updating the external resources
+  workflow_dispatch:
 
 jobs:
   update_external_resources:

--- a/.github/workflows/update-external-resources.yaml
+++ b/.github/workflows/update-external-resources.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Commit JHU CSSE, EBM Data Lab, OWID, CORD-19, and manuscript growth figures
         uses: EndBug/add-and-commit@v4
         with:
-          add: '*/*.png */*.svg'
+          add: '*/*.png */*.svg */*/*.png */*/*.svg'
           author_name: GitHub Actions
           author_email: actions@github.com
           message: 'Update JHU CSSE, EBM Data Lab, OWID, CORD-19, and manuscript growth figures'


### PR DESCRIPTION
This will hopefully address the missing figures in #1070.  I believe that #1072 removed the two missing map figures that were previously on the external resources branch.  However, none of the vaccine map figures are being committed after they are regenerated every night.  That's why the two missing maps weren't added back.

This generalizes the file pattern of image files that are committed in the nightly external resources workflow so that the maps subdirectory is included.