### PR TITLE
Update vaccines refs

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -27,7 +27,7 @@ It is also available as a [PDF]({{manubot.pdf_url_versioned}}).
 {% if individual is defined -%}
 It represents one section of a larger evolving review on SARS-CoV-2 and COVID-19 available at <https://greenelab.github.io/covid19-review/>
 {% else -%}
-Snapshots of individual sections have been published [@individual-pathogenesis; @individual-nutraceuticals; @individual-pharmaceuticals; @individual-methods] or posted as preprints [@individual-diagnostics; @individual-vaccines-traditional; @individual-vaccines-novel].
+Snapshots of individual sections have been published [@individual-pathogenesis; @individual-nutraceuticals; @individual-pharmaceuticals; @individual-methods; @individual-vaccines-traditional; @individual-vaccines-novel] or posted as preprints [@individual-diagnostics].
 {% endif -%}
 </em></small>
 

--- a/content/90.back-matter.md
+++ b/content/90.back-matter.md
@@ -13,5 +13,5 @@
 [@individual-nutraceuticals]: https://pubmed.ncbi.nlm.nih.gov/33947804/
 [@individual-pharmaceuticals]: https://pubmed.ncbi.nlm.nih.gov/34726496/
 [@individual-diagnostics]: arxiv:2204.12598
-[@individual-vaccines-traditional]: arxiv:2208.08907
-[@individual-vaccines-novel]: arxiv:2210.07247
+[@individual-vaccines-traditional]: https://pubmed.ncbi.nlm.nih.gov/36861991/
+[@individual-vaccines-novel]: https://pubmed.ncbi.nlm.nih.gov/36861992/


### PR DESCRIPTION
This updates the citation tags for the vaccines references to use the journal version. The DOI metadata is wrong for these as well but the PubMed URL worked when I tested locally.